### PR TITLE
Change orders quick fixes

### DIFF
--- a/src/main/java/com/tcvcog/tcvce/application/PersonChangesBB.java
+++ b/src/main/java/com/tcvcog/tcvce/application/PersonChangesBB.java
@@ -34,15 +34,15 @@ import javax.faces.application.FacesMessage;
  *
  * @author Nathan Dietz
  */
-public class PersonChangesBB 
-        extends BackingBeanUtils{
-    
+public class PersonChangesBB
+        extends BackingBeanUtils {
+
     private List<PersonWithChanges> currPersonList;
     private PersonWithChanges currPerson;
     private PersonChangeOrder currChangeOrder;
-    
+
     private List<PersonWithChanges> displayList;
-    
+
     private List<ViewOptionsActiveListsEnum> allViewOptions;
     private ViewOptionsActiveListsEnum currentViewOption;
 
@@ -59,22 +59,22 @@ public class PersonChangesBB
             setCurrentViewOption(ViewOptionsActiveListsEnum.VIEW_ACTIVE);
         }
     }
-    
-    public void refreshCurrentObjects(){
-        
+
+    public void refreshCurrentObjects() {
+
         PersonCoordinator pc = getPersonCoordinator();
 
         //let's grab the latest copy of the prop from the database and set it on the session bean
         try {
 
-            if(getSessionBean().getSessPersonList() != null){
-                
+            if (getSessionBean().getSessPersonList() != null) {
+
                 currPersonList = pc.getPersonWithChangesList(getSessionBean().getSessPersonList());
-                
+
             } else {
-                
+
                 currPersonList = new ArrayList<>();
-                
+
                 currPersonList.add(pc.getPersonWithChanges(getSessionBean().getSessPerson().getPersonID()));
             }
 
@@ -84,44 +84,46 @@ public class PersonChangesBB
                     new FacesMessage(FacesMessage.SEVERITY_ERROR,
                             "An error occurred while trying to load information from the database.", ""));
         }
-        
+
         currPerson = new PersonWithChanges();
-        
+
         currChangeOrder = new PersonChangeOrder();
-        
+
     }
-    
+
     /**
-     * Just a little method used by the UI to display 
-     * whether a public user wanted to change a boolean value,
-     * and if so what they want to change it to.
+     * Just a little method used by the UI to display whether a public user
+     * wanted to change a boolean value, and if so what they want to change it
+     * to.
+     *
      * @param input
-     * @return 
+     * @return
      */
-        public String checkForChangeBoolean(String input){
-        
-        if (input == null){
+    public String checkForChangeBoolean(String input) {
+
+        if (input == null) {
             return "No change";
-        } else if (Boolean.valueOf(input)){
+        } else if (Boolean.valueOf(input)) {
             return "Yes";
         } else {
             return "No";
         }
-        
+
     }
-    
-        /**
-         * were we redirected to this page from another?
-         * @return 
-         */
-   public boolean wasRedirected(){
-       return getSessionBean().getNavStack().peekLastPage() != null;
-   }
-        
-    public String goBack(){
-        try{
-        return getSessionBean().getNavStack().popLastPage();
-        }catch(NavigationException ex){
+
+    /**
+     * were we redirected to this page from another?
+     *
+     * @return
+     */
+    public boolean wasRedirected() {
+        return getSessionBean().getNavStack().peekLastPage() != null;
+    }
+
+    public String goBack() {
+        try {
+            return getSessionBean().getNavStack().popLastPage();
+        } catch (NavigationException ex) {
             System.out.println("PersonChangesBB.goBack() | ERROR: " + ex);
             getFacesContext().addMessage(null,
                     new FacesMessage(FacesMessage.SEVERITY_ERROR,
@@ -129,25 +131,23 @@ public class PersonChangesBB
             return "missionControl";
         }
     }
-    
-    public String goToPerson(PersonWithChanges person){
+
+    public String goToPerson(PersonWithChanges person) {
         PersonCoordinator pc = getPersonCoordinator();
-        
+
         getSessionBean().setSessPerson(pc.assemblePersonDataHeavy(person, getSessionBean().getSessUser().getMyCredential()));
-        
+
         getSessionBean().getNavStack().pushCurrentPage();
-        
+
         return "personInfo";
-        
+
     }
-    
-    public void initializeChangeComparison(PersonWithChanges person, PersonChangeOrder change){
+
+    public void initializeChangeComparison(PersonWithChanges person, PersonChangeOrder change) {
         currPerson = person;
         currChangeOrder = change;
     }
-    
-    
-    
+
     public String approvedByWho(PersonChangeOrder change) {
 
         if (change.getApprovedBy() != null) {
@@ -157,19 +157,19 @@ public class PersonChangesBB
                     + " (ID# "
                     + change.getApprovedBy().getPersonID()
                     + ")";
-        } else if(change.isActive()) {
+        } else if (change.isActive()) {
             return "No action taken yet";
         } else {
             return "Rejected";
         }
 
     }
-    
-    public void rejectChangeOrder(){
+
+    public void rejectChangeOrder() {
         PersonIntegrator pi = getPersonIntegrator();
-        
+
         currChangeOrder.setActive(false);
-        
+
         try {
             pi.updatePersonChangeOrder(currChangeOrder);
         } catch (IntegrationException ex) {
@@ -178,14 +178,14 @@ public class PersonChangesBB
                     new FacesMessage(FacesMessage.SEVERITY_ERROR,
                             "An error occurred while trying to update the database.", ""));
         }
-        
+
         setCurrentViewOption(currentViewOption);
-        
+
     }
-    
-    public void applyChangeOrder(){
+
+    public void applyChangeOrder() {
         PersonCoordinator pc = getPersonCoordinator();
-        
+
         try {
             pc.implementPersonChangeOrder(currChangeOrder);
         } catch (IntegrationException ex) {
@@ -194,11 +194,11 @@ public class PersonChangesBB
                     new FacesMessage(FacesMessage.SEVERITY_ERROR,
                             "An error occurred while trying to update the database.", ""));
         }
-        
+
         setCurrentViewOption(currentViewOption);
-        
+
     }
-        
+
     public List<PersonWithChanges> getCurrPersonList() {
         return currPersonList;
     }
@@ -245,7 +245,7 @@ public class PersonChangesBB
 
     public void setCurrentViewOption(ViewOptionsActiveListsEnum input) {
         currentViewOption = input;
-        
+
         refreshCurrentObjects();
 
         currentViewOption = input;
@@ -314,5 +314,5 @@ public class PersonChangesBB
 
         }
     }
-    
+
 }

--- a/src/main/java/com/tcvcog/tcvce/application/PropertyUnitChangesBB.java
+++ b/src/main/java/com/tcvcog/tcvce/application/PropertyUnitChangesBB.java
@@ -19,6 +19,7 @@ package com.tcvcog.tcvce.application;
 import com.tcvcog.tcvce.coordinators.PropertyCoordinator;
 import com.tcvcog.tcvce.domain.BObStatusException;
 import com.tcvcog.tcvce.domain.IntegrationException;
+import com.tcvcog.tcvce.domain.NavigationException;
 import com.tcvcog.tcvce.domain.SearchException;
 import com.tcvcog.tcvce.entities.Property;
 import com.tcvcog.tcvce.entities.PropertyDataHeavy;
@@ -109,6 +110,27 @@ public class PropertyUnitChangesBB
             return "Rejected";
         }
 
+    }
+    
+    /**
+     * were we redirected to this page from another?
+     *
+     * @return
+     */
+    public boolean wasRedirected() {
+        return getSessionBean().getNavStack().peekLastPage() != null;
+    }
+
+    public String goBack() {
+        try {
+            return getSessionBean().getNavStack().popLastPage();
+        } catch (NavigationException ex) {
+            System.out.println("PropertyUnitChangesBB.goBack() | ERROR: " + ex);
+            getFacesContext().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                            "An error occurred while trying to redirect you back to the previous page!", ""));
+            return "missionControl";
+        }
     }
 
     public void initializeChangeComparison(PropertyUnit unit, PropertyUnitChangeOrder change) {

--- a/src/main/java/com/tcvcog/tcvce/coordinators/PublicInfoCoordinator.java
+++ b/src/main/java/com/tcvcog/tcvce/coordinators/PublicInfoCoordinator.java
@@ -521,7 +521,9 @@ public class PublicInfoCoordinator extends BackingBeanUtils implements Serializa
      * @throws BObStatusException
      * @throws SearchException
      */
-    public PublicInfoBundlePropertyUnit extractPublicInfo(PropertyUnit input) throws IntegrationException, EventException, AuthorizationException, BObStatusException, SearchException {
+    public PublicInfoBundlePropertyUnit extractPublicInfo(PropertyUnit input)
+            throws IntegrationException, EventException,
+            AuthorizationException, BObStatusException, SearchException {
         PublicInfoBundlePropertyUnit pib = new PublicInfoBundlePropertyUnit();
         PropertyCoordinator pc = getPropertyCoordinator();
         setPublicUser();

--- a/src/main/java/com/tcvcog/tcvce/entities/Person.java
+++ b/src/main/java/com/tcvcog/tcvce/entities/Person.java
@@ -122,6 +122,67 @@ public  class       Person
     protected ArrayList<Integer> ghostsList;
     protected ArrayList<Integer> cloneList;
     protected ArrayList<Integer> mergedList;
+
+    public Person() {
+    }
+
+    /**
+     * Method for cloning Person objects
+     * 
+     * @param input The person we would like to clone
+     */
+    public Person(Person input) {
+        personID = input.getPersonID(); 
+        personType = input.getPersonType();
+        muniCode = input.getMuniCode();
+        muniName = input.getMuniName();
+        source = input.getSource();
+        creatorUserID = input.getCreatorUserID();
+        creationTimeStamp = input.getCreationTimeStamp();
+        firstName = input.getFirstName();
+        lastName = input.getLastName();
+        compositeLastName = input.isCompositeLastName();
+        businessEntity = input.isBusinessEntity();
+        jobTitle = input.getJobTitle();
+        phoneCell = input.getPhoneCell();
+        phoneHome = input.getPhoneHome();
+        phoneWork = input.getPhoneWork();
+        email = input.getEmail();
+        addressStreet = input.getAddressStreet();
+        addressCity = input.getAddressCity();
+        addressZip = input.getAddressZip();
+        addressState = input.getAddressState();
+        useSeparateMailingAddress = input.isUseSeparateMailingAddress();
+        mailingAddressStreet = input.getMailingAddressStreet();
+        mailingAddressThirdLine = input.getMailingAddressThirdLine();
+        mailingAddressCity = input.getMailingAddressCity();
+        mailingAddressZip = input.getMailingAddressZip();
+        mailingAddressState = input.getMailingAddressState();
+        notes = input.getNotes();
+        lastUpdated = input.getLastUpdated();
+        lastUpdatedPretty = input.getLastUpdatedPretty();
+        canExpire = input.isCanExpire();
+        expiryDate = input.getExpiryDate();
+        expireString = input.getExpireString();
+        expiryDateUtilDate = input.getExpiryDateUtilDate();
+        expiryNotes = input.getExpiryNotes();
+        active = input.isActive();
+        linkedUserID = input.getLinkedUserID();
+        under18 = input.isUnder18();
+        verifiedByUserID = input.getVerifiedByUserID();
+        referencePerson = input.isReferencePerson();
+        ghostCreatedDate = input.getGhostCreatedDate();
+        ghostCreatedDatePretty = input.getGhostCreatedDatePretty();
+        ghostOf = input.getGhostOf();
+        ghostCreatedByUserID = input.getGhostCreatedByUserID();
+        cloneCreatedDate = input.getCloneCreatedDate();
+        cloneCreatedDatePretty = input.getCloneCreatedDatePretty();
+        cloneOf = input.getCloneOf();
+        cloneCreatedByUserID = input.getCloneCreatedByUserID();
+        ghostsList = input.getGhostsList();
+        cloneList = input.getCloneList();
+        mergedList = input.getMergedList();
+    }
     
     
     

--- a/src/main/java/com/tcvcog/tcvce/entities/PropertyUnit.java
+++ b/src/main/java/com/tcvcog/tcvce/entities/PropertyUnit.java
@@ -36,6 +36,24 @@ public class    PropertyUnit
     protected int conditionIntensityClassID;
     protected LocalDateTime lastUpdatedTS;
 
+    public PropertyUnit() {
+    }
+
+    public PropertyUnit(PropertyUnit input){
+        unitID = input.getUnitID();
+        propertyID = input.getPropertyID();
+        unitNumber = input.getUnitNumber();
+        otherKnownAddress = input.getOtherKnownAddress();
+        rentalIntentDateStart = input.getRentalIntentDateStart();
+        rentalIntentDateStop = input.getRentalIntentDateStop();
+        rentalIntentLastUpdatedBy = input.getRentalIntentLastUpdatedBy();
+        notes = input.getNotes();
+        rentalNotes = input.getRentalNotes();
+        active = input.isActive();
+        conditionIntensityClassID = input.getConditionIntensityClassID();
+        lastUpdatedTS = input.getLastUpdatedTS();
+    }
+    
     @Override
     public int hashCode() {
         int hash = 5;

--- a/src/main/java/com/tcvcog/tcvce/entities/PropertyUnitChangeOrder.java
+++ b/src/main/java/com/tcvcog/tcvce/entities/PropertyUnitChangeOrder.java
@@ -54,24 +54,24 @@ public class PropertyUnitChangeOrder extends ChangeOrder {
      */
     public PropertyUnitChangeOrder(PropertyUnit original, PropertyUnit proposed){
         
-                    unitID = proposed.getUnitID();
+        unitID = proposed.getUnitID();
 
-                    //check each field for changes
-                    if (!compareStrings(original.getUnitNumber(), proposed.getUnitNumber())) {
-                        unitNumber = proposed.getUnitNumber();
-                    }
+        //check each field for changes
+        if (!compareStrings(original.getUnitNumber(), proposed.getUnitNumber())) {
+            unitNumber = proposed.getUnitNumber();
+        }
 
-                    if (!compareStrings(original.getOtherKnownAddress(), proposed.getOtherKnownAddress())) {
-                        otherKnownAddress = proposed.getOtherKnownAddress();
-                    }
+        if (!compareStrings(original.getOtherKnownAddress(), proposed.getOtherKnownAddress())) {
+            otherKnownAddress = proposed.getOtherKnownAddress();
+        }
 
-                    if (!compareStrings(original.getNotes(), proposed.getNotes())) {
-                        notes = proposed.getNotes();
-                    }
+        if (!compareStrings(original.getNotes(), proposed.getNotes())) {
+            notes = proposed.getNotes();
+        }
 
-                    if (!compareStrings(original.getRentalNotes(), proposed.getRentalNotes())) {
-                        rentalNotes = proposed.getRentalNotes();
-                    }
+        if (!compareStrings(original.getRentalNotes(), proposed.getRentalNotes())) {
+            rentalNotes = proposed.getRentalNotes();
+        }
         
     }
     

--- a/src/main/java/com/tcvcog/tcvce/integration/PropertyIntegrator.java
+++ b/src/main/java/com/tcvcog/tcvce/integration/PropertyIntegrator.java
@@ -1430,7 +1430,7 @@ public class PropertyIntegrator extends BackingBeanUtils implements Serializable
                 + "FROM\n"
                 + "propertyunitchange\n"
                 + "JOIN propertyunit ON propertyunitchange.propertyunit_unitid = propertyunit.unitid\n"
-                + "WHERE unitid=? AND propertyunitchange.active = true AND propertyunitchange.approvedon IS null;";
+                + "WHERE unitid=? AND propertyunitchange.active = true AND propertyunitchange.approvedondate IS null;";
 
         Connection con = getPostgresCon();
         ResultSet rs = null;

--- a/src/main/java/com/tcvcog/tcvce/occupancy/application/OccPermitApplicationBB.java
+++ b/src/main/java/com/tcvcog/tcvce/occupancy/application/OccPermitApplicationBB.java
@@ -741,13 +741,26 @@ public class OccPermitApplicationBB extends BackingBeanUtils implements Serializ
             return "";
         }
 
-        while (!getSessionBean().getNavStack().peekLastPage().contains("occPermitAddPropertyUnit.xhtml")) { //Clear the navstack until we reach occPermitAddPropertyUnit.xhtml
-            try {
-                getSessionBean().getNavStack().popLastPage();
-            } catch (NavigationException ex) {
-                //nothing, we just wanted to clear the stack anyway.
+        if(redir.contentEquals("selectuntil we reach occPermitAddPropertyUnit.xhtmlForApply")){
+        
+            while (!getSessionBean().getNavStack().peekLastPage().contains("occPermitAddPropertyUnit.xhtml")) { //Clear the navstack until we reach occPermitAddPropertyUnit.xhtml
+                try {
+                    getSessionBean().getNavStack().popLastPage();
+                } catch (NavigationException ex) {
+                    //nothing, we just wanted to clear the stack anyway.
+                }
+            }
+        
+        } else {
+            while (getSessionBean().getNavStack().peekLastPage() != null) { //Clear the navstack completely
+                try {
+                    getSessionBean().getNavStack().popLastPage();
+                } catch (NavigationException ex) {
+                    //nothing, we just wanted to clear the stack anyway.
+                }
             }
         }
+        
 
         return redir;
     }

--- a/src/main/java/com/tcvcog/tcvce/occupancy/application/OccPermitApplicationManageBB.java
+++ b/src/main/java/com/tcvcog/tcvce/occupancy/application/OccPermitApplicationManageBB.java
@@ -752,6 +752,25 @@ public class OccPermitApplicationManageBB extends BackingBeanUtils implements Se
 
         return "personChanges";
     }
+    
+    public String goToUnitChangeOrders() {
+
+        PropertyCoordinator pc = getPropertyCoordinator();
+        
+        try{
+        
+            getSessionBean().setSessProperty(pc.getPropertyByPropUnitID(selectedApplication.getApplicationPropertyUnit().getUnitID()));
+
+            getSessionBean().getNavStack().pushCurrentPage();
+
+        return "unitsChanges";
+        } catch(IntegrationException ex){
+            getFacesContext().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                            "Something when wrong while trying to redirect you to unit changes!", ""));
+            return "";
+        }
+    }
 
     public String acceptUnitListChanges() {
 

--- a/src/main/webapp/public/services/occPermitApplicationFlow/personsRequirementManage.xhtml
+++ b/src/main/webapp/public/services/occPermitApplicationFlow/personsRequirementManage.xhtml
@@ -64,7 +64,8 @@
                                             <p:focus/>
 
                                             <p>
-                                                Use filter(s) below. Click "search". In the list that appears, click to attach the desired people. If you can't find the person you are looking for, Click "Add a person" below and press the pencil to enter their information.
+                                                Use filter(s) below. Click "search". In the list that appears, click to attach the desired people. 
+                                                If you can't find the person you are looking for, Click "Add" below to add a person and press the pencil to enter their information.
                                             </p>
 
                                             <!-- DATA CONTAINER -->
@@ -93,142 +94,6 @@
                                                                  tabindex="3" 
                                                                  placeholder="Filter by email"
                                                                  />
-                                            </div>
-                                        </div>
-
-                                        <p:outputLabel styleClass="public-main-contents-title" value="#{occPermitApplicationBB.currentApplication.reason.humanFriendlyDescription}"/>
-
-                                        <p>1. Attach People From Search Result</p>
-                                        <p:dataTable id="results-dt" 
-                                                     var="person" 
-                                                     value="#{occPermitApplicationBB.personSearchResults}" 
-                                                     scrollable="true" 
-                                                     scrollHeight="150">
-
-                                            <p:column headerText="Last Name">
-                                                <h:outputText value="#{person.bundledPerson.lastName}" />
-                                            </p:column>
-
-                                            <p:column headerText="First Name">
-                                                <h:outputText value="#{person.bundledPerson.firstName}" />
-                                            </p:column>
-
-                                            <p:column headerText="Street Address">
-                                                <h:outputText value="#{person.bundledPerson.addressStreet}" />
-                                            </p:column>
-
-                                            <p:column headerText="Home Phone">
-                                                <h:outputText value="#{person.bundledPerson.phoneHome}" />
-                                            </p:column>
-
-                                            <p:column headerText="Cell Phone">
-                                                <h:outputText value="#{person.bundledPerson.phoneCell}" />
-                                            </p:column>
-
-                                            <p:column headerText="Work Phone">
-                                                <h:outputText value="#{person.bundledPerson.phoneWork}" />
-                                            </p:column>
-
-                                            <p:column headerText="Email">
-                                                <h:outputText value="#{person.bundledPerson.email}" />
-                                            </p:column>
-
-                                            <p:column headerText="Attach" style="text-align: center">
-                                                <p:commandButton ajax="true" 
-                                                                 update=":personsRequirementManageForm" 
-                                                                 action="#{occPermitApplicationBB.addPersonToApplication(person)}" 
-                                                                 id="attach-person-cb" 
-                                                                 value="Attach" />
-                                            </p:column>
-
-                                        </p:dataTable>
-
-                                        <p>
-                                            2. Can't find the person you are looking for? Add a person to the table below and press the pencil to enter their information.
-                                            Click the arrow button below the pencil to fill in more of their contact information.
-                                        </p> 
-
-
-                                        <p:outputLabel value="- #{occPermitApplicationBB.personRequirementDescription.get(0)}"/>
-
-                                        <p:spacer height="10px"/>
-
-                                        <p:outputLabel value="- #{occPermitApplicationBB.personRequirementDescription.get(1)}"/>
-
-                                        <p:spacer height="10px"/>
-
-                                        <p:outputLabel value="- #{occPermitApplicationBB.personRequirementDescription.get(2)}"/>
-
-                                        <p:spacer height="10px"/>
-
-                                        <p:dataTable id="applicationPersonTable"
-                                                     widgetVar="datatable"
-                                                     rowIndexVar="rowIndex"
-                                                     var="applicationPerson" value="#{occPermitApplicationBB.attachedPersons}" 
-                                                     rowKey="#{applicationPerson.bundledPerson.personID}"
-                                                     editable="true">  
-
-                                            <p:column headerText="" style="width: 20px">
-                                                <p:rowToggler/>
-                                            </p:column>
-
-                                            <p:column headerText="Last Name">
-                                                <p:cellEditor>
-                                                    <f:facet name="output"><h:outputText value="#{applicationPerson.bundledPerson.lastName}"/></f:facet>
-                                                    <f:facet name="input">
-                                                        <p:inputText value="#{applicationPerson.bundledPerson.lastName}"
-                                                                     onkeydown="PF('datatable').onKeyDown(event)"
-                                                                     onkeyup="PF('datatable').onKeyUp(event, #{rowIndex})"/>
-                                                    </f:facet>
-                                                </p:cellEditor>
-                                            </p:column>
-
-                                            <p:column headerText="First Name">
-                                                <p:cellEditor>
-                                                    <f:facet name="output"><h:outputText value="#{applicationPerson.bundledPerson.firstName}"/></f:facet>
-                                                    <f:facet name="input">
-                                                        <p:inputText value="#{applicationPerson.bundledPerson.firstName}"
-                                                                     onkeydown="PF('datatable').onKeyDown(event)"
-                                                                     onkeyup="PF('datatable').onKeyUp(event, #{rowIndex})"/>
-                                                    </f:facet>
-                                                </p:cellEditor>
-                                            </p:column>
-
-                                            <p:column headerText="Person Type">
-                                                <p:selectOneMenu value="#{applicationPerson.bundledPerson.personType}">
-                                                    <f:selectItems value="#{occPermitApplicationBB.optAndReqPersons}" var="type" itemLabel="#{type.label}" itemValue="#{type}"/>
-                                                </p:selectOneMenu> 
-                                            </p:column>  
-
-                                            <p:column headerText="Edit" style="width: 20px; text-align: center">
-                                                <p:rowEditor/>
-                                            </p:column>
-
-                                            <p:column headerText="Applicant" style="text-align: center">
-                                                <p:commandButton ajax="true" value="Set as applicant" 
-                                                                 action="#{occPermitApplicationBB.setApplicant(applicationPerson)}"
-                                                                 update="#{p:component('currentApplicantLabel')} #{p:component('currentContactLabel')}"
-                                                                 /> 
-                                            </p:column>
-
-                                            <p:column headerText="Preferred Contact" style="text-align: center">
-                                                <p:commandButton ajax="true" value="Set as preferred contact" 
-                                                                 action="#{occPermitApplicationBB.setContactPerson(applicationPerson)}"
-                                                                 update="#{p:component('currentContactLabel')}"
-                                                                 /> 
-                                            </p:column>
-
-                                            <p:column headerText="Remove" style="text-align: center">
-                                                <p:commandButton ajax="true" value="Remove" 
-                                                                 action="#{occPermitApplicationBB.removePersonFromApplication(applicationPerson)}"
-                                                                 update="#{p:component('applicationPersonTable')}"
-                                                                 /> 
-                                            </p:column>
-
-                                            <p:rowExpansion>
-
-                                                <div class="public-main-contents-title">
-                                                    1. Remember to hit the enter key when you finish filling out a box!
                                                 </div>
 
                                                 <div class="ui-g-12 ui-md-6 ui-lg-2 ">
@@ -331,7 +196,7 @@
 
                                             <!-- DATA CONTAINER -->
                                             <div class="ui-g data-container">
-                                                
+
                                                 <div class="ui-g-12 ui-md-12 ui-lg-12 ">
 
                                                     <p:dataTable id="applicationPersonTable"
@@ -550,7 +415,7 @@
                                                 </div>
                                             </div>
 
-                                            <h:outputText id ="currentApplicantLabel" value="Current Applicant: #{occPermitApplicationBB.applicantName} / "/>
+                                            <h:outputText id ="currentApplicantLabel" value="Current Applicant: #{occPermitApplicationBB.applicantName} | "/>
 
                                             <h:outputText id ="currentContactLabel" value="Preferred Contact: #{occPermitApplicationBB.contactName}"/>
 

--- a/src/main/webapp/public/services/occPermitApplicationFlow/reviewAndSubmit.xhtml
+++ b/src/main/webapp/public/services/occPermitApplicationFlow/reviewAndSubmit.xhtml
@@ -154,7 +154,7 @@
                                     <div class="public-main-contents-button-right" >
                                         <div class="gray_button">
                                             <p:commandButton ajax="false" 
-                                                             value="Return to Unit List" 
+                                                             value="Submit Application and Return to Unit List" 
                                                              styleClass="buttonOwnLine"
                                                              action="#{occPermitApplicationBB.submitApplication('selectForApply')}"
                                                              style="width: 100%;"

--- a/src/main/webapp/restricted/cogstaff/occ/occPermitApplicationUnitList.xhtml
+++ b/src/main/webapp/restricted/cogstaff/occ/occPermitApplicationUnitList.xhtml
@@ -54,6 +54,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <h:outputLabel styleClass="data_field_label" 
                                                        value="Your changes to the unit list at #{occPermitApplicationManageBB.propertyForApplication.address} will be saved to the database
                                                        should you accept them."/>
+                                        <br />
+                                        <h:outputLabel styleClass="data_field_label" 
+                                                       value="WARNING: Make sure to check public-proposed changes to units before editing the unit list."/>
+                                       
                                     </div>
 
                                     <div class="ui-g-12 ui-md-6 ui-lg-3 data_field">

--- a/src/main/webapp/restricted/cogstaff/occ/occPermitApplications.xhtml
+++ b/src/main/webapp/restricted/cogstaff/occ/occPermitApplications.xhtml
@@ -533,6 +533,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                         <p:outputLabel value="Edit unit list for this property?"/>
                                                         <p:spacer height="5px"/>
                                                         <div class="cearActionsTableOutputLabel">
+                                                            <p:commandButton    id="go-to-unit-change-list-cb"
+                                                                    value="Check for public-proposed changes to units"
+                                                                    rendered="#{systemServicesBB.bbSessionUser.keyCard.hasEnfOfficialPermissions}"
+                                                                    disabled="#{empty occPermitApplicationManageBB.selectedApplication}"
+                                                                    action="#{occPermitApplicationManageBB.goToUnitChangeOrders()}"
+                                                                    icon="fa fa-gears"/>
                                                             <p:commandButton    id="edit-unit-list-cb"
                                                                                 value="Edit"
                                                                                 rendered="#{systemServicesBB.bbSessionUser.keyCard.hasEnfOfficialPermissions}"

--- a/src/main/webapp/restricted/cogstaff/occ/occPermitNewPeriod.xhtml
+++ b/src/main/webapp/restricted/cogstaff/occ/occPermitNewPeriod.xhtml
@@ -247,6 +247,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                        value="Please type a message explaining your approval of their application. This message, your name, and a timestamp 
                                                        will be appended to the public note section of application ID #{occPermitApplicationManageBB.selectedApplication.id} 
                                                        as well as the newly created Occupancy Period."/>
+                                        <br />
+                                        <h:outputLabel styleClass="data_field_label" 
+                                                       value="WARNING: Make sure to check public-proposed changes to units and persons before approving a Occupancy Permit Application!"/>
                                         <p:inputTextarea id="acceptMessageITA" style="width: 300px; height: 200px;" value="#{occPermitApplicationManageBB.acceptApplicationMessage}"/>
                                     </div>
 

--- a/src/main/webapp/restricted/cogstaff/prop/propertyUnitChanges.xhtml
+++ b/src/main/webapp/restricted/cogstaff/prop/propertyUnitChanges.xhtml
@@ -49,6 +49,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                             <h:form id="select-view-option-form">
 
+                                <p:commandButton rendered="#{propertyUnitChangesBB.wasRedirected()}"
+                                                 value="Finish and return"
+                                                 action="#{propertyUnitChangesBB.goBack()}"
+                                                 />
+                                
+                                <p:spacer height="10px"/>
+                                
                                 <p:outputLabel value="What changes would you like to edit?"/>
 
                                 <p:selectOneMenu style="width: 300px;" 


### PR DESCRIPTION
Fixes a few issues that were found after merging #164 
One was an issue where the XHTML was scrambled on `personsRequirementManage.xhtml`, and there were a few buttons missing on other pages.

Also corrected some errors pertaining to recording change orders, property units, and persons to the database at the end of the Occupancy Permit Application workflow. Now the workflow doesn't create duplicate changes, persons, or units.